### PR TITLE
Add explicit namespace "shiny::" for registerInputHandler

### DIFF
--- a/036-custom-input-control/chooser.R
+++ b/036-custom-input-control/chooser.R
@@ -32,7 +32,7 @@ chooserInput <- function(inputId, leftLabel, rightLabel, leftChoices, rightChoic
   )
 }
 
-registerInputHandler("shinyjsexamples.chooser", function(data, ...) {
+shiny::registerInputHandler("shinyjsexamples.chooser", function(data, ...) {
   if (is.null(data))
     NULL
   else


### PR DESCRIPTION
When this code was included in a package, the build failed with... Error in registerInputHandler("shinyjsexamples.chooser", function(data,  : could not find function "registerInputHandler".
This is fixed in this commit by namespacing to shiny.